### PR TITLE
Parameterised terms: fixed term compatibility + spurious pyright errors

### DIFF
--- a/diffrax/_adjoint.py
+++ b/diffrax/_adjoint.py
@@ -1,8 +1,8 @@
 import abc
 import functools as ft
 import warnings
-from collections.abc import Iterable
-from typing import Any, Optional, Union
+from collections.abc import Callable, Iterable
+from typing import Any, cast, Optional, Union
 
 import equinox as eqx
 import equinox.internal as eqxi
@@ -18,6 +18,9 @@ from ._heuristics import is_sde, is_unsafe_sde
 from ._saveat import save_y, SaveAt, SubSaveAt
 from ._solver import AbstractItoSolver, AbstractRungeKutta, AbstractStratonovichSolver
 from ._term import AbstractTerm, AdjointTerm
+
+
+ω = cast(Callable, ω)
 
 
 def _is_none(x):

--- a/diffrax/_global_interpolation.py
+++ b/diffrax/_global_interpolation.py
@@ -1,6 +1,6 @@
 import functools as ft
 from collections.abc import Callable
-from typing import Optional, TYPE_CHECKING
+from typing import cast, Optional, TYPE_CHECKING
 
 import equinox as eqx
 import equinox.internal as eqxi
@@ -22,6 +22,9 @@ from ._custom_types import DenseInfos, IntScalarLike, RealScalarLike, Y
 from ._local_interpolation import AbstractLocalInterpolation
 from ._misc import fill_forward, left_broadcast_to
 from ._path import AbstractPath
+
+
+ω = cast(Callable, ω)
 
 
 class AbstractGlobalInterpolation(AbstractPath):

--- a/diffrax/_integrate.py
+++ b/diffrax/_integrate.py
@@ -2,7 +2,14 @@ import functools as ft
 import typing
 import warnings
 from collections.abc import Callable
-from typing import Any, get_args, get_origin, Optional, Tuple, TYPE_CHECKING
+from typing import (
+    Any,
+    get_args,
+    get_origin,
+    Optional,
+    Tuple,
+    TYPE_CHECKING,
+)
 
 import equinox as eqx
 import equinox.internal as eqxi
@@ -11,7 +18,6 @@ import jax.core
 import jax.numpy as jnp
 import jax.tree_util as jtu
 import lineax.internal as lxi
-import typeguard
 from jaxtyping import Array, ArrayLike, Float, Inexact, PyTree, Real
 
 from ._adjoint import AbstractAdjoint, RecursiveCheckpointAdjoint
@@ -50,6 +56,7 @@ from ._step_size_controller import (
     StepTo,
 )
 from ._term import AbstractTerm, MultiTerm, ODETerm, WrapTerm
+from ._typing import better_isinstance, get_args_of, get_origin_no_specials
 
 
 class SaveState(eqx.Module):
@@ -79,40 +86,6 @@ class State(eqx.Module):
     progress_meter_state: PyTree[Array]
 
 
-def _better_isinstance(x, annotation) -> bool:
-    """isinstance check for parameterized generics.
-
-    !!! Example
-        ```python
-        x = (1, jnp.array([2.0]))
-        y = ("test", Float[Array, "foo"])
-        expected_type = tuple[int, Float[Array, "foo"]]
-
-        assert _better_isinstance(x, expected_type) # passes as expected.
-        assert _better_isinstance(y, expected_type) # raises AssertionError as expected.
-
-        # Whereas with isinstance:
-        assert isinstance(x, expected_type) # raises TypeError.
-        assert isinstance(y, expected_type) # raises TypeError.
-        ```
-    """
-
-    @typeguard.typechecked
-    def f(y: annotation):
-        pass
-
-    try:
-        f(x)
-    except TypeError:
-        return False
-    else:
-        return True
-
-
-def _assert_term_arg(x, term_arg) -> bool:
-    return _better_isinstance(x, term_arg)
-
-
 def _is_none(x: Any) -> bool:
     return x is None
 
@@ -123,20 +96,26 @@ def _term_compatible(
     terms: PyTree[AbstractTerm],
     term_structure: PyTree,
 ) -> bool:
-    def _check(term_cls, term):
-        if get_origin(term_cls) is MultiTerm:
+    error_msg = "term_structure"
+
+    def _check(term_cls, term, yi):
+        if get_origin_no_specials(term_cls, error_msg) is MultiTerm:
             if isinstance(term, MultiTerm):
                 [_tmp] = get_args(term_cls)
                 assert get_origin(_tmp) in (tuple, Tuple), "Malformed term_structure"
-                if _term_compatible(y, args, term.terms, get_args(_tmp)):
-                    return
-            raise ValueError
+                assert len(term.terms) == len(get_args(_tmp))
+                for term, arg in zip(term.terms, get_args(_tmp)):
+                    if not _term_compatible(yi, args, term, arg):
+                        raise ValueError
+            else:
+                raise ValueError
         else:
             # Check that `term` is an instance of `term_cls` (ignoring any generic
             # parameterization).
-            origin_cls = get_origin(term_cls)
-            _term_cls = origin_cls if origin_cls is not None else term_cls
-            if not isinstance(term, _term_cls):
+            origin_cls = get_origin_no_specials(term_cls, error_msg)
+            if origin_cls is None:
+                origin_cls = term_cls
+            if not isinstance(term, origin_cls):
                 raise ValueError
 
             # Now check the generic parametrization of `term_cls`; can be one of:
@@ -144,31 +123,32 @@ def _term_compatible(
             # `term_cls`                | `term_args`
             # --------------------------|--------------
             # AbstractTerm              | ()
-            # AbstractTerm[VF]          | (VF,)
             # AbstractTerm[VF, Control] | (VF, Control)
             # -----------------------------------------
-            term_args = get_args(term_cls)
+            term_args = get_args_of(AbstractTerm, term_cls, error_msg)
             n_term_args = len(term_args)
-            if n_term_args >= 1:
-                vf_type = eqx.filter_eval_shape(term.vf, 0.0, y, args)
-                vf_type_expected = term_args[0]
+            if n_term_args == 0:
+                pass
+            elif n_term_args == 2:
+                vf_type_expected, control_type_expected = term_args
+                vf_type = eqx.filter_eval_shape(term.vf, 0.0, yi, args)
                 vf_type_compatible = eqx.filter_eval_shape(
-                    _assert_term_arg, vf_type, vf_type_expected
+                    better_isinstance, vf_type, vf_type_expected
                 )
                 if not vf_type_compatible:
                     raise ValueError
-            if n_term_args == 2:
                 control_type = jax.eval_shape(term.contr, 0.0, 0.0)
-                control_type_expected = term_args[1]
                 control_type_compatible = eqx.filter_eval_shape(
-                    _assert_term_arg, control_type, control_type_expected
+                    better_isinstance, control_type, control_type_expected
                 )
                 if not control_type_compatible:
                     raise ValueError
-            return  # If we've got to this point then the term is compatible
+            else:
+                assert False, "Malformed term structure"
+            # If we've got to this point then the term is compatible
 
     try:
-        jtu.tree_map(_check, term_structure, terms)
+        jtu.tree_map(_check, term_structure, terms, y)
     except ValueError:
         # ValueError may also arise from mismatched tree structures
         return False
@@ -732,47 +712,6 @@ def diffeqsolve(
             stacklevel=2,
         )
 
-    # Backward compatibility
-    if isinstance(
-        solver, (EulerHeun, ItoMilstein, StratonovichMilstein)
-    ) and _term_compatible(y0, args, terms, (ODETerm, AbstractTerm)):
-        warnings.warn(
-            "Passing `terms=(ODETerm(...), SomeOtherTerm(...))` to "
-            f"{solver.__class__.__name__} is deprecated in favour of "
-            "`terms=MultiTerm(ODETerm(...), SomeOtherTerm(...))`. This means that "
-            "the same terms can now be passed used for both general and SDE-specific "
-            "solvers!",
-            stacklevel=2,
-        )
-        terms = MultiTerm(*terms)
-
-    # Error checking
-    if not _term_compatible(y0, args, terms, solver.term_structure):
-        raise ValueError(
-            "`terms` must be a PyTree of `AbstractTerms` (such as `ODETerm`), with "
-            f"structure {solver.term_structure}"
-        )
-
-    if is_sde(terms):
-        if not isinstance(solver, (AbstractItoSolver, AbstractStratonovichSolver)):
-            warnings.warn(
-                f"`{type(solver).__name__}` is not marked as converging to either the "
-                "Itô or the Stratonovich solution.",
-                stacklevel=2,
-            )
-        if isinstance(stepsize_controller, AbstractAdaptiveStepSizeController):
-            # Specific check to not work even if using HalfSolver(Euler())
-            if isinstance(solver, Euler):
-                raise ValueError(
-                    "An SDE should not be solved with adaptive step sizes with Euler's "
-                    "method, as it may not converge to the correct solution."
-                )
-    if is_unsafe_sde(terms):
-        if isinstance(stepsize_controller, AbstractAdaptiveStepSizeController):
-            raise ValueError(
-                "`UnsafeBrownianPath` cannot be used with adaptive step sizes."
-            )
-
     # Allow setting e.g. t0 as an int with dt0 as a float.
     timelikes = [t0, t1, dt0] + [
         s.ts for s in jtu.tree_leaves(saveat.subs, is_leaf=_is_subsaveat)
@@ -815,6 +754,47 @@ def diffeqsolve(
 
     y0 = jtu.tree_map(_promote, y0)
     del timelikes
+
+    # Backward compatibility
+    if isinstance(
+        solver, (EulerHeun, ItoMilstein, StratonovichMilstein)
+    ) and _term_compatible(y0, args, terms, (ODETerm, AbstractTerm)):
+        warnings.warn(
+            "Passing `terms=(ODETerm(...), SomeOtherTerm(...))` to "
+            f"{solver.__class__.__name__} is deprecated in favour of "
+            "`terms=MultiTerm(ODETerm(...), SomeOtherTerm(...))`. This means that "
+            "the same terms can now be passed used for both general and SDE-specific "
+            "solvers!",
+            stacklevel=2,
+        )
+        terms = MultiTerm(*terms)
+
+    # Error checking
+    if not _term_compatible(y0, args, terms, solver.term_structure):
+        raise ValueError(
+            "`terms` must be a PyTree of `AbstractTerms` (such as `ODETerm`), with "
+            f"structure {solver.term_structure}"
+        )
+
+    if is_sde(terms):
+        if not isinstance(solver, (AbstractItoSolver, AbstractStratonovichSolver)):
+            warnings.warn(
+                f"`{type(solver).__name__}` is not marked as converging to either the "
+                "Itô or the Stratonovich solution.",
+                stacklevel=2,
+            )
+        if isinstance(stepsize_controller, AbstractAdaptiveStepSizeController):
+            # Specific check to not work even if using HalfSolver(Euler())
+            if isinstance(solver, Euler):
+                raise ValueError(
+                    "An SDE should not be solved with adaptive step sizes with Euler's "
+                    "method, as it may not converge to the correct solution."
+                )
+    if is_unsafe_sde(terms):
+        if isinstance(stepsize_controller, AbstractAdaptiveStepSizeController):
+            raise ValueError(
+                "`UnsafeBrownianPath` cannot be used with adaptive step sizes."
+            )
 
     # Normalises time: if t0 > t1 then flip things around.
     direction = jnp.where(t0 < t1, 1, -1)

--- a/diffrax/_local_interpolation.py
+++ b/diffrax/_local_interpolation.py
@@ -1,4 +1,5 @@
-from typing import Optional, TYPE_CHECKING
+from collections.abc import Callable
+from typing import cast, Optional, TYPE_CHECKING
 
 import jax.numpy as jnp
 import jax.tree_util as jtu
@@ -15,6 +16,9 @@ from jaxtyping import Array, ArrayLike, PyTree, Shaped
 from ._custom_types import RealScalarLike, Y
 from ._misc import linear_rescale
 from ._path import AbstractPath
+
+
+ω = cast(Callable, ω)
 
 
 class AbstractLocalInterpolation(AbstractPath):

--- a/diffrax/_root_finder/_verychord.py
+++ b/diffrax/_root_finder/_verychord.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import Any
+from typing import Any, cast
 
 import equinox as eqx
 import jax
@@ -13,6 +13,9 @@ from equinox.internal import ω
 from jaxtyping import Array, Bool, PyTree, Scalar
 
 from .._custom_types import Y
+
+
+ω = cast(Callable, ω)
 
 
 def _small(diffsize: Scalar) -> Bool[Array, ""]:

--- a/diffrax/_solver/sil3.py
+++ b/diffrax/_solver/sil3.py
@@ -1,4 +1,5 @@
-from typing import ClassVar
+from collections.abc import Callable
+from typing import cast, ClassVar
 
 import numpy as np
 import optimistix as optx
@@ -13,6 +14,9 @@ from .runge_kutta import (
     CalculateJacobian,
     MultiButcherTableau,
 )
+
+
+ω = cast(Callable, ω)
 
 
 # See

--- a/diffrax/_step_size_controller/adaptive.py
+++ b/diffrax/_step_size_controller/adaptive.py
@@ -33,6 +33,9 @@ from .._term import AbstractTerm, ODETerm
 from .base import AbstractStepSizeController
 
 
+ω = cast(Callable, ω)
+
+
 def _select_initial_step(
     terms: PyTree[AbstractTerm],
     t0: RealScalarLike,

--- a/diffrax/_step_size_controller/constant.py
+++ b/diffrax/_step_size_controller/constant.py
@@ -47,7 +47,7 @@ class ConstantStepSize(AbstractStepSizeController[RealScalarLike, RealScalarLike
         y1_candidate: Y,
         args: Args,
         y_error: Optional[Y],
-        error_order: RealScalarLike,
+        error_order: Optional[RealScalarLike],
         controller_state: RealScalarLike,
     ) -> tuple[bool, RealScalarLike, RealScalarLike, bool, RealScalarLike, RESULTS]:
         del t0, y0, y1_candidate, args, y_error, error_order

--- a/diffrax/_typing.py
+++ b/diffrax/_typing.py
@@ -1,0 +1,184 @@
+import inspect
+import sys
+import types
+from typing import (
+    Annotated,
+    Any,
+    Generic,
+    get_args,
+    get_origin,
+    Optional,
+    Protocol,
+    TypeVar,
+    Union,
+)
+from typing_extensions import TypeAlias
+
+import typeguard
+
+
+# We don't actually care what people have subscripted with.
+# In practice this should be thought of as TypeLike = Union[type, types.UnionType]. Plus
+# maybe type(Literal) and so on?
+TypeLike: TypeAlias = Any
+
+
+def better_isinstance(x, annotation) -> bool:
+    """As `isinstance`, but supports general type hints."""
+
+    @typeguard.typechecked
+    def f(y: annotation):
+        pass
+
+    try:
+        f(x)
+    except TypeError:
+        return False
+    else:
+        return True
+
+
+_union_types: list = [Union]
+if sys.version_info >= (3, 10):
+    _union_types.append(types.UnionType)
+
+
+def get_origin_no_specials(x, error_msg: str) -> Optional[type]:
+    """As `typing.get_origin`, but ignores `Annotated` and throws a
+    `NotImplementedError` if passed any other non-class: `Union`, `Literal`, etc. Serves
+    as a guard against the full weirdness of the Python type system.
+
+    **Arguments:**
+
+    - `x`: the type to apply `get_origin` to.
+    - `error_msg`: if a disallowed type is used, then this will appear in the error
+        message.
+
+    **Returns:**
+
+    As `get_origin`, specifically either `None` or a class.
+    """
+    origin = get_origin(x)
+    if origin in _union_types:
+        raise NotImplementedError(f"Cannot use unions in `{error_msg}`.")
+    elif origin is Annotated:
+        # We do allow Annotated, just because it's easy to handle.
+        return get_origin_no_specials(get_args(x)[0], error_msg)
+    elif origin is None or inspect.isclass(origin):
+        return origin
+    else:
+        raise NotImplementedError(f"Cannot use {x} in `{error_msg}`.")
+
+
+def get_args_of(base_cls: type, cls, error_msg: str) -> tuple[TypeLike, ...]:
+    """Equivalent to `get_args(cls)`, except that it tracks through the type hierarchy
+    finding the way in which `cls` subclasses `base_cls`, and returns the arguments that
+    subscript that instead.
+
+    For example,
+    ```python
+    class Foo(Generic[T]):
+        pass
+
+    class Bar(Generic[S]):
+        pass
+
+    class Qux(Foo[T], Bar[S]):
+        pass
+
+    get_args_of(Foo, Qux[int, str], "...")  # int
+    ```
+
+    In addition, any unfilled type variables are returned as `Any`.
+
+    **Arguments:**
+
+    - `base_cls`: the class to get parameters with respect to.
+    - `cls`: the class or subscripted generic to get arguments with respect to.
+    - `error_msg`: if anything goes wrong, mention this in the error message.
+
+    **Returns:**
+
+    A tuple of types indicating the arguments. In addition, any unfilled type variables
+    are returned as `Any`.
+    """
+
+    if not inspect.isclass(base_cls):
+        raise TypeError(f"{base_cls} should be a class")
+    if not hasattr(base_cls, "__parameters__"):
+        raise TypeError(f"{base_cls} should be an unsubscripted generic")
+
+    origin = get_origin_no_specials(cls, error_msg)
+    if inspect.isclass(cls):
+        # Unsubscripted
+        assert origin is None
+        origin = cls
+        params = [Any for _ in getattr(cls, "__parameters__", ())]
+    else:
+        # Subscripted
+        assert origin is not None
+        params: list[TypeLike] = []
+        for param in get_args(cls):
+            if isinstance(param, TypeVar):
+                params.append(Any)
+            else:
+                params.append(param)
+    if issubclass(origin, base_cls):
+        out = _get_args_of_impl(base_cls, origin, tuple(params), error_msg)
+        if out is None:
+            # Dependency is purely inheritance without subscripting
+            return tuple(Any for _ in base_cls.__parameters__)
+        else:
+            return out
+    else:
+        raise TypeError(f"{cls} is not a subclass of {base_cls}")
+
+
+def _get_args_of_impl(
+    base_cls: type, cls: type, params: tuple[TypeLike, ...], error_msg
+) -> Optional[tuple[TypeLike, ...]]:
+    if cls is base_cls:
+        return params
+    assert len(cls.__parameters__) == len(params)
+    param_lookup = {k: v for k, v in zip(cls.__parameters__, params)}
+    base_params: set[tuple[TypeLike, ...]] = set()
+    # If we've gotten this far then `cls` is known to have been subscripted, so it
+    # should have an `__orig_bases__` attribute. (Where as e.g. `class Foo: pass` does
+    # not have one)
+    for x in cls.__orig_bases__:
+        x_origin = get_origin_no_specials(x, error_msg)
+        if x_origin in (Generic, Protocol):
+            continue
+        if inspect.isclass(x):
+            # Unsubscripted, ignore.
+            assert x_origin is None
+        else:
+            # Subscripted, should pass in parameters
+            assert x_origin is not None
+            assert len(get_args(x)) > 0
+            x_params = [
+                param_lookup.get(arg, Any) if isinstance(arg, TypeVar) else arg
+                for arg in get_args(x)
+            ]
+            if issubclass(x_origin, base_cls):
+                base_params_i = _get_args_of_impl(
+                    base_cls, x_origin, tuple(x_params), error_msg
+                )
+                if base_params_i is not None:
+                    base_params.add(base_params_i)
+            # Else ignore, we won't be able to recurse down to `base_cls` this way.
+    if len(base_params) == 0:
+        # `base_cls` is a superclass of `cls`, as we have earlier guards against this.
+        assert issubclass(cls, base_cls)
+        # However that dependency is purely normal inheritance, no subscripting.
+        return None
+    elif len(base_params) == 1:
+        return base_params.pop()
+    else:
+        if len(params) == 0:
+            error_cls = cls
+        else:
+            error_cls = cls[params]
+        raise TypeError(
+            f"{error_cls} inherits from {base_cls} in multiple incompatible ways."
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Mathematics",
 ]
 urls = {repository = "https://github.com/patrick-kidger/diffrax" }
-dependencies = ["jax>=0.4.23", "jaxtyping>=0.2.24", "typing_extensions>=4.5.0", "typeguard>=2.13.3", "equinox>=0.11.2", "lineax>=0.0.4", "optimistix>=0.0.6"]
+dependencies = ["jax>=0.4.23", "jaxtyping>=0.2.24", "typing_extensions>=4.5.0", "typeguard==2.13.3", "equinox>=0.11.2", "lineax>=0.0.4", "optimistix>=0.0.6"]
 
 [build-system]
 requires = ["hatchling"]
@@ -38,11 +38,13 @@ markers = ["slow"]
 
 [tool.ruff]
 extend-include = ["*.ipynb"]
+src = []
+
+[tool.ruff.lint]
 fixable = ["I001", "F401"]
 ignore = ["E402", "E721", "E731", "E741", "F722"]
 ignore-init-module-imports = true
 select = ["E", "F", "I001"]
-src = []
 
 [tool.ruff.lint.isort]
 combine-as-imports = true
@@ -52,4 +54,5 @@ order-by-type = false
 
 [tool.pyright]
 reportIncompatibleMethodOverride = true
+reportIncompatibleVariableOverride = false  # Incompatible with eqx.AbstractVar
 include = ["diffrax", "tests"]

--- a/test/test_typing.py
+++ b/test/test_typing.py
@@ -1,0 +1,296 @@
+from typing import Annotated, Any, Generic, Literal, TypeVar, Union
+
+import diffrax as dfx
+import pytest
+from diffrax._custom_types import RealScalarLike
+from diffrax._typing import get_args_of, get_origin_no_specials
+
+
+T = TypeVar("T")
+S = TypeVar("S")
+U = TypeVar("U")
+
+
+class Foo(Generic[T]):
+    pass
+
+
+class Bar(Generic[S]):
+    pass
+
+
+class Baz:
+    pass
+
+
+def test_get_origin_no_specials():
+    assert get_origin_no_specials(int, "") is None
+    assert get_origin_no_specials(tuple[int, ...], "") is tuple
+    assert get_origin_no_specials(Foo[int], "") is Foo
+    assert get_origin_no_specials(Annotated[tuple[int, ...], 1337], "") is tuple
+    # Weird, but legal
+    assert get_origin_no_specials(Generic[T], "") is Generic  # pyright: ignore
+
+    with pytest.raises(NotImplementedError, match="qwerty"):
+        get_origin_no_specials(Union[int, str], "qwerty")
+    with pytest.raises(NotImplementedError, match="qwerty"):
+        get_origin_no_specials(Literal[4], "qwerty")  # pyright: ignore
+
+
+def test_get_args_of_not_generic():
+    with pytest.raises(TypeError, match="unsubscripted generic"):
+        get_args_of(Baz, Foo, "")
+    with pytest.raises(TypeError, match="unsubscripted generic"):
+        get_args_of(Baz, Foo[int], "")
+    with pytest.raises(TypeError, match="unsubscripted generic"):
+        get_args_of(int, Foo, "")
+
+
+def test_get_args_of_not_subclass():
+    with pytest.raises(TypeError, match="is not a subclass"):
+        get_args_of(Foo, Bar, "")
+    with pytest.raises(TypeError, match="is not a subclass"):
+        get_args_of(Foo, Baz, "")
+    with pytest.raises(TypeError, match="is not a subclass"):
+        get_args_of(Foo, int, "")
+
+
+def test_get_args_of_single_inheritance():
+    class Qux1(Foo):
+        pass
+
+    class Qux2(Foo[int]):
+        pass
+
+    class Qux3(Foo[T]):
+        pass
+
+    assert get_args_of(Foo, Qux1, "") == (Any,)
+    assert get_args_of(Foo, Qux2, "") == (int,)
+    assert get_args_of(Foo, Qux3, "") == (Any,)
+    assert get_args_of(Foo, Qux3[str], "") == (str,)
+
+
+def test_get_args_irrelevant_inheritance():
+    class Qux1(Foo, str):
+        pass
+
+    class Qux2(Foo[int], str):
+        pass
+
+    class Qux3(Foo[T], str):
+        pass
+
+    assert get_args_of(Foo, Qux1, "") == (Any,)
+    assert get_args_of(Foo, Qux2, "") == (int,)
+    assert get_args_of(Foo, Qux3, "") == (Any,)
+    assert get_args_of(Foo, Qux3[str], "") == (str,)
+
+
+def test_get_args_double_inheritance():
+    class Qux1(Foo, Bar):
+        pass
+
+    class Qux2(Foo[int], Bar):
+        pass
+
+    class Qux3(Foo[T], Bar):
+        pass
+
+    assert get_args_of(Foo, Qux1, "") == (Any,)
+    assert get_args_of(Foo, Qux2, "") == (int,)
+    assert get_args_of(Foo, Qux3, "") == (Any,)
+    assert get_args_of(Foo, Qux3[bool], "") == (bool,)
+
+    class Qux4(Foo, Bar[str]):
+        pass
+
+    class Qux5(Foo[int], Bar[str]):
+        pass
+
+    class Qux6(Foo[T], Bar[str]):
+        pass
+
+    assert get_args_of(Foo, Qux4, "") == (Any,)
+    assert get_args_of(Foo, Qux5, "") == (int,)
+    assert get_args_of(Foo, Qux6, "") == (Any,)
+    assert get_args_of(Foo, Qux6[bool], "") == (bool,)
+
+    class Qux7(Foo, Bar[S]):
+        pass
+
+    class Qux8(Foo[int], Bar[S]):
+        pass
+
+    class Qux9(Foo[T], Bar[S]):
+        pass
+
+    assert get_args_of(Foo, Qux7, "") == (Any,)
+    assert get_args_of(Foo, Qux7[bool], "") == (Any,)
+    assert get_args_of(Foo, Qux8, "") == (int,)
+    assert get_args_of(Foo, Qux8[bool], "") == (int,)
+    assert get_args_of(Foo, Qux9, "") == (Any,)
+    assert get_args_of(Foo, Qux9[bool, str], "") == (bool,)
+
+    class Qux10(Foo, Bar[T]):
+        pass
+
+    class Qux11(Foo[int], Bar[T]):
+        pass
+
+    class Qux12(Foo[T], Bar[T]):
+        pass
+
+    assert get_args_of(Foo, Qux10, "") == (Any,)
+    assert get_args_of(Foo, Qux11, "") == (int,)
+    assert get_args_of(Foo, Qux12, "") == (Any,)
+    assert get_args_of(Foo, Qux12[bool], "") == (bool,)
+
+
+def test_get_args_double_inheritance_reverse():
+    class Qux1(Foo, Bar):
+        pass
+
+    class Qux2(Foo[int], Bar):
+        pass
+
+    class Qux3(Foo[T], Bar):
+        pass
+
+    assert get_args_of(Bar, Qux1, "") == (Any,)
+    assert get_args_of(Bar, Qux2, "") == (Any,)
+    assert get_args_of(Bar, Qux3, "") == (Any,)
+    assert get_args_of(Bar, Qux3[bool], "") == (Any,)
+
+    class Qux4(Foo, Bar[str]):
+        pass
+
+    class Qux5(Foo[int], Bar[str]):
+        pass
+
+    class Qux6(Foo[T], Bar[str]):
+        pass
+
+    assert get_args_of(Bar, Qux4, "") == (str,)
+    assert get_args_of(Bar, Qux5, "") == (str,)
+    assert get_args_of(Bar, Qux6, "") == (str,)
+    assert get_args_of(Bar, Qux6[bool], "") == (str,)
+
+    class Qux7(Foo, Bar[S]):
+        pass
+
+    class Qux8(Foo[int], Bar[S]):
+        pass
+
+    class Qux9(Foo[T], Bar[S]):
+        pass
+
+    assert get_args_of(Bar, Qux7, "") == (Any,)
+    assert get_args_of(Bar, Qux7[bool], "") == (bool,)
+    assert get_args_of(Bar, Qux8, "") == (Any,)
+    assert get_args_of(Bar, Qux8[bool], "") == (bool,)
+    assert get_args_of(Bar, Qux9, "") == (Any,)
+    assert get_args_of(Bar, Qux9[bool, str], "") == (str,)
+
+    class Qux10(Foo, Bar[T]):
+        pass
+
+    class Qux11(Foo[int], Bar[T]):
+        pass
+
+    class Qux12(Foo[T], Bar[T]):
+        pass
+
+    assert get_args_of(Bar, Qux10, "") == (Any,)
+    assert get_args_of(Bar, Qux11, "") == (Any,)
+    assert get_args_of(Bar, Qux12, "") == (Any,)
+    assert get_args_of(Bar, Qux12[bool], "") == (bool,)
+
+
+def test_get_args_of_complicated():
+    class X1(Generic[T, S]):
+        pass
+
+    class X2(X1[T, T], Generic[T, S]):
+        pass
+
+    class X3(X2):
+        pass
+
+    class X4(X2[int, T]):
+        pass
+
+    class X5(str, X1[str, str]):
+        pass
+
+    class X6(X1[S, T], Generic[T, U, S]):
+        pass
+
+    # This one is invalid at static type-checking time.
+    class X7(X6[int, str, bool], X2[int, str]):  # pyright: ignore
+        pass
+
+    class X8(X6[bool, T, bool], X2[bool, int]):
+        pass
+
+    class X9(X3, X2[int, str]):
+        pass
+
+    # Some of these are invalid at static type-checking time.
+    assert get_args_of(X1, X1, "") == (Any, Any)
+    assert get_args_of(X1, X1[int, S], "") == (int, Any)  # pyright: ignore
+    assert get_args_of(X1, X1[int, str], "") == (int, str)
+
+    assert get_args_of(X1, X2, "") == (Any, Any)
+    assert get_args_of(X1, X2[T, str], "") == (Any, Any)  # pyright: ignore
+    assert get_args_of(X1, X2[str, T], "") == (str, str)  # pyright: ignore
+    assert get_args_of(X1, X2[int, str], "") == (int, int)
+
+    assert get_args_of(X2, X3, "") == (Any, Any)
+
+    assert get_args_of(X2, X4, "") == (int, Any)
+    assert get_args_of(X2, X4[str], "") == (int, str)
+
+    assert get_args_of(X1, X5, "") == (str, str)
+
+    assert get_args_of(X1, X6, "") == (Any, Any)
+    assert get_args_of(X1, X6[int, str, bool], "") == (bool, int)
+
+    with pytest.raises(TypeError, match="multiple incompatible ways"):
+        assert get_args_of(X1, X7, "") == (Any, Any)
+    assert get_args_of(X6, X7, "") == (int, str, bool)
+    assert get_args_of(X2, X7, "") == (int, str)
+
+    assert get_args_of(X1, X8, "") == (bool, bool)
+    assert get_args_of(X1, X8[float], "") == (bool, bool)
+    assert get_args_of(X6, X8, "") == (bool, Any, bool)
+    assert get_args_of(X6, X8[float], "") == (bool, float, bool)
+    assert get_args_of(X2, X8, "") == (bool, int)
+    assert get_args_of(X2, X8[float], "") == (bool, int)
+
+    assert get_args_of(X3, X9, "") == ()
+    assert get_args_of(X2, X9, "") == (int, str)
+    assert get_args_of(X1, X9, "") == (int, int)
+
+
+_abstract_args = lambda cls: get_args_of(dfx.AbstractTerm, cls, "")
+
+
+def test_abstract_term():
+    assert _abstract_args(dfx.AbstractTerm) == (Any, Any)
+    assert _abstract_args(dfx.AbstractTerm[int, str]) == (int, str)
+
+
+def test_ode_term():
+    assert _abstract_args(dfx.ODETerm) == (Any, RealScalarLike)
+    assert _abstract_args(dfx.ODETerm[int]) == (int, RealScalarLike)
+
+
+def test_control_term():
+    assert _abstract_args(dfx.ControlTerm) == (Any, Any)
+    assert _abstract_args(dfx.ControlTerm[int, str]) == (int, str)
+
+
+def test_weakly_diagonal_control_term():
+    assert _abstract_args(dfx.WeaklyDiagonalControlTerm) == (Any, Any)
+    assert _abstract_args(dfx.WeaklyDiagonalControlTerm[int, str]) == (int, str)


### PR DESCRIPTION
Phew, this ended up being a complicated one!

Let's start with the easy stuff:
- Disabled spurious pyright errors due to incompatibility between pyright and `eqx.AbstractVar`.
- Now using ruff.lint and pinned exact typeguard version.

Now on to the hard stuff:
- Fixed term compatibility missing some edge cases.

Edge cases? What edge cases? Well, what we had before was basically predicated around doing
```python
vf, contr = get_args(term_cls)
```
recalling that we may have e.g. `term_cls = AbstractTerm[SomeVectorField, SomeControl]`. So far so simple: get the arguments of a subscripted generic, no big deal.

What this failed to account for is that we may also have subclasses of this generic, e.g. `term_cls = ODETerm[SomeVectorField]`, such that some of the type variables have already been filled in when defining it:
```python
class ODETerm(AbstractTerm[_VF, RealScaleLike]): ...
```
so in this case, `get_args(term_cls)` simply returns a 1-tuple of `(SomeVectorField,)`. Oh no! Somehow we have to traverse both the filled-in type variables (to find that one of our type variables is `SomeVectorField` due to subscripting) *and* the type hierarchy (to figure out that the other type variable was filled in during the definition).

Once again, for clarity: given a subscriptable base class `AbstractTerm[_VF, _Control]` and some arbitrary possible-subscripted subclass, we need to find the values of `_VF` and `_Control`, regardless of whehther they have been passed in via subscripting the final class (and are `get_args`-able) or have been filled in during subclassing (and require traversing pseudo-type-hierarchies of `__orig_bases__`).

Any sane implementation would simply... not bother. There is no way that the hassle of figuring this out was going to be worth the small amount of type safety this brings...

So anyway, after a few hours working on this *far* past the point I should be going to sleep, this problem this is now solved. This PR introduces a new `get_args_of` function, called as `get_args_of(superclass, subclass, error_msg_if_necessary)`. This acts analogous to `get_args`, but instead of looking up both parameters (the type variables we want filled in) and the arguments (the values those type variables have been filled in with) on the same class, it looks up the parameters on the superclass, and their filled-in-values on the subclass. Pure madness.

(I'm also tagging @leycec here because this is exactly the kind of insane typing hackery that he seems to really enjoy.)

Does anyone else remember the days when this was a package primarily concerned about solving differential equations?